### PR TITLE
get_url need become false

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,8 +25,9 @@
   delay: 2
   delegate_to: localhost
   check_mode: false
+  become: false
 
-- name: Unpack node_exporter binary
+- name: Unpack apache_exporter binary
   unarchive:
     src: "/tmp/apache_exporter-{{ apache_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "/tmp"


### PR DESCRIPTION
Hi, 
If role is executed with become, the task get_url fail.
Adding become: false attribute seems to resolve the problem.

Also fix a typo (node_exporter instead of apache_exporter)

Thanks