### PR TITLE
Apache_exporter parameters need double dash

### DIFF
--- a/templates/apache_exporter.service.j2
+++ b/templates/apache_exporter.service.j2
@@ -8,9 +8,9 @@ Group={{ apache_exporter_system_group }}
 
 ExecStart=/usr/local/bin/apache_exporter \
 {% if apache_exporter_ignore_https %}
-          -insecure \
+          --insecure \
 {% endif %}
-          -scrape_uri {{ apache_exporter_scrape_uri }} \
-          -telemetry.address {{ apache_exporter_telemetry_address }} \
-          -telemetry.endpoint {{ apache_exporter_telemetry_endpoint }}
+          --scrape_uri {{ apache_exporter_scrape_uri }} \
+          --telemetry.address {{ apache_exporter_telemetry_address }} \
+          --telemetry.endpoint {{ apache_exporter_telemetry_endpoint }}
 


### PR DESCRIPTION
All parameters to launch apache_exporter are with single dash in template, from ?? it's not woarking anymore.
This PR contain correction to add double dash to all parameters