### PR TITLE
Add ability to perform download and installation of apache_exporter b…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 apache_exporter_version: 0.5.0
 
 # Must we perform download and propagation from localhost (true) or not (false)
-apache_exporter_download_localhost: false
+apache_exporter_download_localhost: true
 
 apache_exporter_system_group: apache-exp
 apache_exporter_system_user: "{{ apache_exporter_system_group }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 
 apache_exporter_version: 0.5.0
 
+# Must we perform download and propagation from localhost (true) or not (false)
+apache_exporter_download_localhost: false
+
 apache_exporter_system_group: apache-exp
 apache_exporter_system_user: "{{ apache_exporter_system_group }}"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,19 +19,21 @@
   get_url:
     url: "{{ apache_exporter_download_url }}"
     dest: "/tmp/apache_exporter-{{ apache_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+  become: "{{ false if not apache_exporter_download_localhost is defined else omit }}"
   register: __download_binary
   until: __download_binary is succeeded
   retries: 5
   delay: 2
-  delegate_to: localhost
+  delegate_to: "{{ 'localhost' if apache_exporter_download_localhost else inventory_hostname }}"
   check_mode: false
 
-- name: Unpack node_exporter binary
+- name: Unpack apache_exporter binary
   unarchive:
     src: "/tmp/apache_exporter-{{ apache_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "/tmp"
     creates: "/tmp/apache_exporter-{{ apache_exporter_version }}.linux-{{ go_arch }}/apache_exporter"
-  delegate_to: localhost
+  become: "{{ false if not apache_exporter_download_localhost else omit }}"
+  delegate_to: "{{ 'localhost' if apache_exporter_download_localhost else inventory_hostname }}"
   check_mode: false
   become: false
 
@@ -48,4 +50,5 @@
     mode: 0750
     owner: "{{ apache_exporter_system_user }}"
     group: "{{ apache_exporter_system_group }}"
+    remote_src: "{{ false if apache_exporter_download_localhost else true }}"
   notify: restart apache_exporter

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,9 +32,8 @@
     src: "/tmp/apache_exporter-{{ apache_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "/tmp"
     creates: "/tmp/apache_exporter-{{ apache_exporter_version }}.linux-{{ go_arch }}/apache_exporter"
-  become: "{{ false if not apache_exporter_download_localhost else omit }}"
   delegate_to: "{{ 'localhost' if apache_exporter_download_localhost else inventory_hostname }}"
-  check_mode: false
+  become: "{{ false if not apache_exporter_download_localhost else omit }}"
   become: false
 
 - name: Create local bin dir


### PR DESCRIPTION
By default apache_exporter release is downloaded on local machine (running Ansible) and propagated on remote server.
It can be very long if you upload speed isn't efficient.

With this option, installation can be done 100% on remote host, no more problem with transfert speed.